### PR TITLE
Add support for Role and Rolebinding

### DIFF
--- a/cmd/tree.go
+++ b/cmd/tree.go
@@ -58,7 +58,28 @@ var treeCmd = &cobra.Command{
 					}
 					crTree.AddTree(crbTree)
 				}
+				for _, rb := range cr.RoleBindings {
+					rbname := fmt.Sprintf("%v/%v", rb.Namespace, rb.Name)
+					rbTree := gotree.New(fmt.Sprintf("📓 RoleBinding "+printers.GreenString, rbname))
+					for _, sub := range rb.Subjects {
+						rbTree.Add(fmt.Sprintf("📗 Subject{Kind: "+printers.CianString+", Name: "+printers.RedString+", Namespace: "+printers.BlueString+"}", sub.Kind, sub.Name, sub.Namespace))
+					}
+					crTree.AddTree(rbTree)
+				}
 				pspTree.AddTree(crTree)
+			}
+			for _, r := range psp.Roles {
+				rname := fmt.Sprintf("%v/%v", r.Namespace, r.Name)
+				rTree := gotree.New(fmt.Sprintf("📓 Role "+printers.GreenString, rname))
+				for _, rb := range r.RoleBindings {
+					rbname := fmt.Sprintf("%v/%v", r.Namespace, rb.Name)
+					rbTree := gotree.New(fmt.Sprintf("📓 RoleBinding "+printers.GreenString, rbname))
+					for _, sub := range rb.Subjects {
+						rbTree.Add(fmt.Sprintf("📗 Subject{Kind: "+printers.CianString+", Name: "+printers.RedString+", Namespace: "+printers.BlueString+"}", sub.Kind, sub.Name, sub.Namespace))
+					}
+					rTree.AddTree(rbTree)
+				}
+				pspTree.AddTree(rTree)
 			}
 			fmt.Fprintln(w, pspTree.Print())
 		}

--- a/pkg/rbac/clusterrole.go
+++ b/pkg/rbac/clusterrole.go
@@ -58,7 +58,7 @@ func CreatePSPRole(ctx context.Context, k8sclient *kubernetes.Clientset, psp *po
 	return CreateClusterRole(ctx, k8sclient, clusterRole)
 }
 
-func ListUsePSPRole(ctx context.Context, k8sclient *kubernetes.Clientset) (*rbacv1.ClusterRoleList, error) {
+func ListClusterRolesWithPSP(ctx context.Context, k8sclient *kubernetes.Clientset) (*rbacv1.ClusterRoleList, error) {
 	clusterRoleList, err := k8sclient.RbacV1().ClusterRoles().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err

--- a/pkg/rbac/clusterrole.go
+++ b/pkg/rbac/clusterrole.go
@@ -68,49 +68,10 @@ func ListUsePSPRole(ctx context.Context, k8sclient *kubernetes.Clientset) (*rbac
 	pspClusterRoleList.Items = make([]rbacv1.ClusterRole, 0)
 
 	for _, cr := range clusterRoleList.Items {
-		pspNames := ExtractPSPNamesFromClusterRole(cr)
+		pspNames := ExtractPSPFromGenericRole(cr)
 		if len(pspNames) != 0 {
 			pspClusterRoleList.Items = append(pspClusterRoleList.Items, cr)
 		}
 	}
 	return pspClusterRoleList, nil
-}
-
-func ExtractPSPNamesFromClusterRole(cr rbacv1.ClusterRole) []string {
-	pspNames := make([]string, 0)
-	for _, rule := range cr.Rules {
-		if hasApiGroupsPolicy(rule) && hasResourcePSP(rule) && hasVerbUse(rule) {
-			for _, resourceName := range rule.ResourceNames {
-				pspNames = append(pspNames, resourceName)
-			}
-		}
-	}
-	return pspNames
-}
-
-func hasApiGroupsPolicy(rule rbacv1.PolicyRule) bool {
-	for _, apiGroups := range rule.APIGroups {
-		if apiGroups == "policy" {
-			return true
-		}
-	}
-	return false
-}
-
-func hasResourcePSP(rule rbacv1.PolicyRule) bool {
-	for _, resource := range rule.Resources {
-		if resource == "podsecuritypolicies" {
-			return true
-		}
-	}
-	return false
-}
-
-func hasVerbUse(rule rbacv1.PolicyRule) bool {
-	for _, verb := range rule.Verbs {
-		if verb == "use" {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/rbac/role.go
+++ b/pkg/rbac/role.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2020 jlandowner.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbac
+
+import (
+	"context"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func ListRolesWithPSP(ctx context.Context, k8sclient *kubernetes.Clientset) (*rbacv1.RoleList, error) {
+	roleList, err := k8sclient.RbacV1().Roles("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	pspRoleList := roleList.DeepCopy()
+	pspRoleList.Items = make([]rbacv1.Role, 0)
+
+	for _, r := range roleList.Items {
+		pspNames := ExtractPSPFromGenericRole(r)
+		if len(pspNames) != 0 {
+			pspRoleList.Items = append(pspRoleList.Items, r)
+		}
+	}
+	return pspRoleList, nil
+}
+
+func ListRoleBindings(ctx context.Context, k8sclient *kubernetes.Clientset) (*rbacv1.RoleBindingList, error) {
+	return k8sclient.RbacV1().RoleBindings("").List(ctx, metav1.ListOptions{})
+}

--- a/pkg/rbac/rule.go
+++ b/pkg/rbac/rule.go
@@ -42,7 +42,7 @@ func ExtractPSPFromGenericRole(r interface{}) []string {
 
 func hasAPIGroupsPolicy(rule rbacv1.PolicyRule) bool {
 	for _, apiGroups := range rule.APIGroups {
-		if apiGroups == "policy" {
+		if apiGroups == "policy" || apiGroups == "extensions" {
 			return true
 		}
 	}

--- a/pkg/rbac/rule.go
+++ b/pkg/rbac/rule.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2020 jlandowner.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbac
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func ExtractPSPFromGenericRole(r interface{}) []string {
+	var rules []rbacv1.PolicyRule
+
+	switch r := r.(type) {
+	case rbacv1.ClusterRole:
+		rules = r.Rules
+	case rbacv1.Role:
+		rules = r.Rules
+	}
+
+	pspNames := make([]string, 0)
+	for _, rule := range rules {
+		if hasAPIGroupsPolicy(rule) && hasResourcePSP(rule) && hasVerbUse(rule) {
+			for _, resourceName := range rule.ResourceNames {
+				pspNames = append(pspNames, resourceName)
+			}
+		}
+	}
+	return pspNames
+}
+
+func hasAPIGroupsPolicy(rule rbacv1.PolicyRule) bool {
+	for _, apiGroups := range rule.APIGroups {
+		if apiGroups == "policy" {
+			return true
+		}
+	}
+	return false
+}
+
+func hasResourcePSP(rule rbacv1.PolicyRule) bool {
+	for _, resource := range rule.Resources {
+		if resource == "podsecuritypolicies" {
+			return true
+		}
+	}
+	return false
+}
+
+func hasVerbUse(rule rbacv1.PolicyRule) bool {
+	for _, verb := range rule.Verbs {
+		if verb == "use" {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/relations/relations.go
+++ b/pkg/relations/relations.go
@@ -66,25 +66,6 @@ func GetRelationalPSPs(ctx context.Context, k8sclient *kubernetes.Clientset) ([]
 	return rpsps, nil
 }
 
-func GetRelationalPSP(ctx context.Context, k8sclient *kubernetes.Clientset, name string) (*RelationalPodSecurityPolicy, error) {
-	apiPsp, err := policy.GetPSP(ctx, k8sclient, name)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to get PSP: %v", err.Error())
-	}
-
-	apiCrList, err := rbac.ListUsePSPRole(ctx, k8sclient)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to list ClusterRole: %v", err.Error())
-	}
-
-	apiCrbList, err := rbac.ListClusterRoleBindings(ctx, k8sclient)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to list ClusterRole: %v", err.Error())
-	}
-
-	return generateRelationalPSP(apiPsp, apiCrList, apiCrbList), nil
-}
-
 func generateRelationalPSP(apiPsp *policyv1.PodSecurityPolicy, apiCrList *rbacv1.ClusterRoleList, apiCrbList *rbacv1.ClusterRoleBindingList) *RelationalPodSecurityPolicy {
 	rpsp := &RelationalPodSecurityPolicy{PodSecurityPolicy: *apiPsp}
 

--- a/pkg/relations/relations.go
+++ b/pkg/relations/relations.go
@@ -89,7 +89,7 @@ func generateRelationalPSP(apiPsp *policyv1.PodSecurityPolicy, apiCrList *rbacv1
 	rpsp := &RelationalPodSecurityPolicy{PodSecurityPolicy: *apiPsp}
 
 	for _, apicr := range apiCrList.Items {
-		pspNames := rbac.ExtractPSPNamesFromClusterRole(apicr)
+		pspNames := rbac.ExtractPSPFromGenericRole(apicr)
 		for _, pspName := range pspNames {
 			if rpsp.Name == pspName {
 				rpsp.ClusterRoles = append(rpsp.ClusterRoles, RelationalClusterRole{ClusterRole: apicr})


### PR DESCRIPTION
Example `psp-util tree` command run with PSP reference from role and rolebinding

```
PSP-NAME                       CLUSTER-ROLE                       CLUSTER-ROLE-BINDING               NS/ROLE                    NS/ROLE-BINDING            PSP-UTIL-MANAGED
kps-alertmanager                                                                                     default/kps-alertmanager   default/kps-alertmanager   false
kps-grafana                                                                                          default/kps-grafana        default/kps-grafana        false
kps-grafana-test                                                                                     default/kps-grafana-test   default/kps-grafana-test   false
kps-kube-state-metrics         psp-kps-kube-state-metrics         psp-kps-kube-state-metrics                                                               false
kps-operator                   kps-operator-psp                   kps-operator-psp                                                                         false
kps-prometheus                 kps-prometheus-psp                 kps-prometheus-psp                                                                       false
kps-prometheus-node-exporter   psp-kps-prometheus-node-exporter   psp-kps-prometheus-node-exporter                                                         false
``` 

Example `psp-util tree` command run

```
📙 PSP kps-alertmanager
└── 📓 Role default/kps-alertmanager
    └── 📓 RoleBinding default/kps-alertmanager
        └── 📗 Subject{Kind: ServiceAccount, Name: kps-alertmanager, Namespace: default}

📙 PSP kps-grafana
└── 📓 Role default/kps-grafana
    └── 📓 RoleBinding default/kps-grafana
        └── 📗 Subject{Kind: ServiceAccount, Name: kps-grafana, Namespace: default}

📙 PSP kps-grafana-test
└── 📓 Role default/kps-grafana-test
    └── 📓 RoleBinding default/kps-grafana-test
        └── 📗 Subject{Kind: ServiceAccount, Name: kps-grafana-test, Namespace: default}

📙 PSP kps-kube-state-metrics
└── 📕 ClusterRole psp-kps-kube-state-metrics
    └── 📘 ClusterRoleBinding psp-kps-kube-state-metrics
        └── 📗 Subject{Kind: ServiceAccount, Name: kps-kube-state-metrics, Namespace: default}

📙 PSP kps-operator
└── 📕 ClusterRole kps-operator-psp
    └── 📘 ClusterRoleBinding kps-operator-psp
        └── 📗 Subject{Kind: ServiceAccount, Name: kps-operator, Namespace: default}

📙 PSP kps-prometheus
└── 📕 ClusterRole kps-prometheus-psp
    └── 📘 ClusterRoleBinding kps-prometheus-psp
        └── 📗 Subject{Kind: ServiceAccount, Name: kps-prometheus, Namespace: default}

📙 PSP kps-prometheus-node-exporter
└── 📕 ClusterRole psp-kps-prometheus-node-exporter
    └── 📘 ClusterRoleBinding psp-kps-prometheus-node-exporter
        └── 📗 Subject{Kind: ServiceAccount, Name: kps-prometheus-node-exporter, Namespace: default}
```